### PR TITLE
Clean profiles for apparmor 2.12+

### DIFF
--- a/src/lib/clean.c
+++ b/src/lib/clean.c
@@ -62,7 +62,7 @@ bool aa_hook_context_clean_cache(AaHookContext *self)
                 return false;
         }
 
-        char *path[] = { self->cache_dir, NULL };
+        char *path[] = { (char *)self->cache_dir, NULL };
         file_system = fts_open(path, FTS_PHYSICAL | FTS_NOSTAT, NULL);
 
         if (file_system == NULL) {

--- a/src/lib/clean.c
+++ b/src/lib/clean.c
@@ -74,7 +74,7 @@ bool aa_hook_context_clean_cache(AaHookContext *self)
                 if (path_info != FTS_F || path_info != FTS_NSOK || path_info != FTS_DP) {
                         continue;
                 }
-                if (path_info != FTS_F || path_info != FTS_NSOK) {
+                if (path_info == FTS_F || path_info == FTS_NSOK) {
                         /* Ignore the .features file and profiles that are still installed */
                         if (strcmp(curr_entry->fts_name, ".features") == 0 ||
                             aa_hook_context_has_cache(self, curr_entry->fts_name)) {

--- a/src/lib/clean.c
+++ b/src/lib/clean.c
@@ -81,21 +81,19 @@ bool aa_hook_context_clean_cache(AaHookContext *self)
                                 continue;
                         }
                 }
-                if (remove(curr_entry->fts_path) == 0) {
-                        /* Print for benefit of calling tool */
-                        fprintf(stdout,
-                                "aa_hook_context_clean_cache(): Removed %s\n",
-                                curr_entry->fts_name);
-                } else {
-                        if (errno != ENOTEMPTY) {
-                                /* It's OK if dir was not empty, but print other error cases */
-                                fprintf(stderr,
-                                        "Unable to remove() %s: %s\n",
-                                        curr_entry->fts_path,
-                                        strerror(errno));
-                                ret = false;
-                        }
+                if (remove(curr_entry->fts_path) != 0 && errno != ENOTEMPTY) {
+                        /* It's OK if dir was not empty, but print other error cases */
+                        fprintf(stderr,
+                                "Unable to remove() %s: %s\n",
+                                curr_entry->fts_path,
+                                strerror(errno));
+                        ret = false;
+                        continue;
                 }
+                /* Removal succeedeed. Print it for benefit of calling tool */
+                fprintf(stdout,
+                        "aa_hook_context_clean_cache(): Removed %s\n",
+                        curr_entry->fts_name);
         }
         fts_close(file_system);
         return ret;


### PR DESCRIPTION
AppArmor changed the cache directory structure in v2.12 to include subdirectories.
The previous implementation of `aa_hook_context_clean_cache()` assumed that in
the cache directory there could be only files, that's why it failed on cleaning
a non-empty directory.
This patch reworks the `aa_hook_context_clean_cache()` logic to fully traverse
the cache directory to remove old profiles first, and then empty directories if any.