### PR TITLE
Better error handling for aa_hook_context_clean_cache()

### DIFF
--- a/src/lib/clean.c
+++ b/src/lib/clean.c
@@ -82,7 +82,7 @@ bool aa_hook_context_clean_cache(AaHookContext *self)
                         continue;
                 }
 
-                if (path_info != FTS_F || path_info != FTS_NSOK || path_info != FTS_DP) {
+                if (path_info != FTS_F && path_info != FTS_NSOK && path_info != FTS_DP) {
                         continue;
                 }
                 if (path_info == FTS_F || path_info == FTS_NSOK) {


### PR DESCRIPTION
I figured out I had missed some error handling for `fts_read()`. This PR should cover every error case.
Sorry for not having figured it out earlier, I'm still familiarizing with C.