### PR TITLE
Makefile: Ensure non executable permissions on data files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ setup-deps:
 install:
 	@$(call stage,INSTALL)
 	install -Dm 00755 $(PKGNAME) $(DESTDIR)$(BINDIR)/$(PKGNAME)
-	install -Dm 00755 data/aa-lsm-hook.conf $(DESTDIR)$(SYSCONFDIR)/aa-lsm-hook.conf
-	install -Dm 00755 data/aa-lsm-hook.service $(DESTDIR)$(LIBDIR)/systemd/system/aa-lsm-hook.service
+	install -Dm 00644 data/aa-lsm-hook.conf $(DESTDIR)$(SYSCONFDIR)/aa-lsm-hook.conf
+	install -Dm 00644 data/aa-lsm-hook.service $(DESTDIR)$(LIBDIR)/systemd/system/aa-lsm-hook.service
 	@$(call pass,INSTALL)
 
 uninstall:


### PR DESCRIPTION
system complains about these files being executable, as it should.
These are data-only files and cannot be executed by anything, so make
sure they're 00644 for packaging.

Signed-off-by: Ikey Doherty <ikey.doherty@lispysnake.com>