### PR TITLE
Clean up old cache directories

### DIFF
--- a/aa-lsm-hook.go
+++ b/aa-lsm-hook.go
@@ -34,6 +34,10 @@ func main() {
 		fmt.Println("You must be root to run this program")
 		os.Exit(1)
 	}
+	if err = cache.Init(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
 	if err = cache.Update(); err != nil { // Update cache on disk
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/aa-lsm-hook.go
+++ b/aa-lsm-hook.go
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 	if u.Uid != "0" || u.Gid != "0" { // Not running as root
-		err = fmt.Errorf("You must be root to run this program")
+		fmt.Println("You must be root to run this program")
 		os.Exit(1)
 	}
 	if err = cache.Update(); err != nil { // Update cache on disk

--- a/cache/clean.go
+++ b/cache/clean.go
@@ -17,9 +17,11 @@
 package cache
 
 import (
-	"github.com/getsolus/aa-lsm-hook/profiles"
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/getsolus/aa-lsm-hook/profiles"
 )
 
 // FindNewest gets the newest entry in the list of entries
@@ -70,13 +72,30 @@ func Clean(profs, cached profiles.ProfMap) error {
 			}
 			continue
 		}
-		/* TODO: Why is this here?
-		// Remove all but the entries for the newest profile
-		newest := FindNewest(profs[name])
-		if err := DeleteOlder(name, newest, entries); err != nil {
-			return err
-		}
-		*/
 	}
+
+	return nil
+}
+
+// CleanDirs cleans outdated directories
+func CleanDirs() error {
+	curDir, err := CurrentDir()
+	if err != nil {
+		return err
+	}
+
+	paths, err := ScanDirs()
+	if err != nil {
+		return err
+	}
+
+	for _, path := range paths {
+		if path != curDir {
+			if err = os.RemoveAll(path); err != nil {
+				return fmt.Errorf("failed to remove old cache directory: %w", err)
+			}
+		}
+	}
+
 	return nil
 }

--- a/cache/init.go
+++ b/cache/init.go
@@ -1,0 +1,21 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/getsolus/aa-lsm-hook/config"
+)
+
+// Init initializes the cache directory.
+func Init() error {
+	if _, err := os.Stat(config.AppArmorCache); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if err := os.Mkdir(config.AppArmorCache, config.AppArmorCachePermissions); err != nil {
+			return fmt.Errorf("failed to initialize apparmor cache: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cache/load.go
+++ b/cache/load.go
@@ -17,13 +17,30 @@
 package cache
 
 import (
+	"bytes"
 	"fmt"
-	"github.com/getsolus/aa-lsm-hook/config"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+
+	"github.com/getsolus/aa-lsm-hook/config"
 )
+
+// CurrentDir returns the path of the current cache directory.
+func CurrentDir() (string, error) {
+	out := &bytes.Buffer{}
+
+	cmd := exec.Command("apparmor_parser", "--print-cache-dir")
+	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to get current cache directory: %w", err)
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}
 
 func loadDir(path string) error {
 	cmd := exec.Command("apparmor_parser",

--- a/cache/scan.go
+++ b/cache/scan.go
@@ -17,6 +17,9 @@
 package cache
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/getsolus/aa-lsm-hook/config"
 	"github.com/getsolus/aa-lsm-hook/profiles"
 )
@@ -26,4 +29,21 @@ func Scan() (profiles.ProfMap, error) {
 	profs := make(profiles.ProfMap)
 	err := profs.AddProfiles(config.AppArmorCache)
 	return profs, err
+}
+
+// ScanDirs returns all the currently cached directories.
+func ScanDirs() ([]string, error) {
+	entries, err := os.ReadDir(config.AppArmorCache)
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			dirs = append(dirs, filepath.Join(config.AppArmorCache, entry.Name()))
+		}
+	}
+
+	return dirs, nil
 }

--- a/cache/update.go
+++ b/cache/update.go
@@ -23,6 +23,9 @@ import (
 
 // Update rebuilds all of the profiles in the cache and cleans up the cache
 func Update() error {
+	if err := CleanDirs(); err != nil {
+		return err
+	}
 	dirs, err := config.ProfileDirs() // Get the profile directories
 	if err != nil {
 		return err

--- a/config/apparmor.go
+++ b/config/apparmor.go
@@ -18,3 +18,6 @@ package config
 
 // AppArmorCache is the location of the AppArmor cache that we are managing
 const AppArmorCache = "/var/cache/apparmor"
+
+// AppArmorCachePermissions are the permission of the AppArmor cache when being created.
+const AppArmorCachePermissions = 0700


### PR DESCRIPTION
Implement a new cleanup path by cleaning up non-managed directories.
The current cleanup mechanism only cleans up non-managed profiles but keeps all the old profiles
intact. This is insufficient, as old profiles might fail to load.
There used to be a mechanism to remove older profiles that compared the timestamps on disk between
source and cache (which was disabled for being overzealous), but also might not clean up all the
necessary profiles.

This implementation uses the `apparmor_parser --print-cache-dir` command to get the currently active
cache directory and removes the other (older/incorrect) directories.

This PR also includes two other minor quality of life changes: a fix for the error when not running `aa-lsm-hook` as root, and creation of the cache directory when it doesn't exist (so you can do `rm -rf /var/cache/apparmor` when it is broken).