### PR TITLE
Remove special-case for snapd apparmor profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ The `aa-lsm-hook.service` systemd unit should be enabled instead of any provided
 
 To integrate the compilation step, you'll need a hook in your package manager/update process to execute `aa-lsm-hook` when the apparmor paths change on disk, i.e. `/etc/apparmor.d`.
 
-### Quirks
-
-Currently we have a special-case path to compile the `snapd` profiles from `/var/lib/snapd/apparmor/profiles` into the cache if they exist, which ensures the binary load step will work properly on boot. Without this quirk/workaround, the snapd AppArmor profiles wouldn't be loaded **until** `snapd` is directly started and causes broken snaps. With this .. quirk, everything works correctly, boot time is not regressed, and snaps work for those that have them.
-
 ## Authors
 
 Copyright © 2018-2020 Solus Project <copyright@getsol.us>

--- a/data/aa-lsm-hook.conf
+++ b/data/aa-lsm-hook.conf
@@ -1,2 +1,1 @@
 /etc/apparmor.d
-/var/lib/snapd/apparmor/profiles

--- a/data/aa-lsm-hook.service
+++ b/data/aa-lsm-hook.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Load AppArmor profiles
 DefaultDependencies=no
-After=local-fs.target snapd.service
+After=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Snapd is transitioning to apparmor-ABI pinned security profiles, so that ongoing updates to the kernel do not give new meaning to the existing security profiles (don't break userspace principle).

Out of several possible ways that this can be achieved, the most pragmatic one turned out to involve passing a non-default value to apparmor_parser, along with a path to a file internally managed by snapd, see [1].

Since snapd introduced snapd.apparmor.service several years ago, it can already control compilation and loading of compiled profiles into the kernel and distribution-managed apparmor profiles no longer need to understand or special-case snapd profiles in any way.

By removing this we make aa-lsm-hook compatible with the upcoming change in snapd. At some point in time omission of the ABI pinned profiles may lead to unexpected behavior changes to applications running under snap confinement.

[1] https://github.com/snapcore/snapd/pull/13711